### PR TITLE
add option to save poster and banner images locally

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ export default class MovieSearchPlugin extends Plugin {
 		console.log(
 			`Movie Search: version ${this.manifest.version} (requires obsidian ${this.manifest.minAppVersion})`,
 		);
-	}
+	}me
 
 	show_notice(message: unknown) {
 		try {
@@ -298,7 +298,8 @@ export default class MovieSearchPlugin extends Plugin {
 		const image = await download_image(movie[variable], movie.title);
 
 		if (image) {
-			image.file_name = `${movie.title}${suffix}`;
+			const sanitizedTitle = movie.title.replace(/:/g, "");
+			image.file_name = `${sanitizedTitle}${suffix}`;
 			await save_to_folder(this.app, local_path, image);
 			movie[variable] = `${image.file_name}.${image.extension}`;
 		}

--- a/src/models/downloaded_image.model.ts
+++ b/src/models/downloaded_image.model.ts
@@ -1,0 +1,5 @@
+export interface DownloadedImage {
+	content: ArrayBuffer;
+	file_name: string;
+	extension: string;
+}

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -18,6 +18,7 @@ export interface MovieSearchPluginSettings {
 	folder: string; // new file location
 	file_name_format: string; // new file name format
 	template_file: string;
+	local_image_path: string;
 	open_page_on_completion: boolean;
 	locale_preference: string;
 	ask_preferred_locale: boolean;
@@ -40,6 +41,7 @@ export const DEFAULT_SETTINGS: MovieSearchPluginSettings = {
 	folder: "",
 	file_name_format: "",
 	template_file: "",
+	local_image_path: "",
 	open_page_on_completion: true,
 	locale_preference: "auto",
 	ask_preferred_locale: false,
@@ -127,6 +129,22 @@ export class MovieSearchSettingTab extends PluginSettingTab {
 					.onChange(new_template_file => {
 						this.plugin.settings.template_file = new_template_file;
 						this.plugin.saveSettings();
+					});
+			});
+		new Setting(containerEl)
+			.setName("Local Images Folder")
+			.setDesc("Folder where banner and cover images will be downloaded. Leave empty to disable local images.")
+			.addSearch(cb => {
+				try {
+					new FolderSuggest(this.app, cb.inputEl);
+				} catch {
+					// eslint-disable
+				}
+				cb.setPlaceholder("Example: attachments/images")
+					.setValue(this.plugin.settings.local_image_path ?? "")
+					.onChange(async value => {
+						this.plugin.settings.local_image_path = value.trim();
+						await this.plugin.saveSettings();
 					});
 			});
 		new Setting(containerEl)

--- a/src/utils/image_downloader.ts
+++ b/src/utils/image_downloader.ts
@@ -1,0 +1,56 @@
+import { DownloadedImage } from "@models/downloaded_image.model";
+import { App, normalizePath, requestUrl } from "obsidian";
+
+export async function download_image(image_url: string, file_name: string): Promise<DownloadedImage | null> {
+	try {
+		const res = await requestUrl({
+			url: image_url,
+			method: "GET",
+		});
+
+		return {
+			content: res.arrayBuffer,
+			file_name: file_name,
+			extension: get_extension(image_url),
+		};
+	} catch (e) {
+		console.warn("Failed to download image", e);
+		return null;
+	}
+}
+
+function get_extension(url: string): string {
+	const clean = url.split("?")[0].split("#")[0];
+
+	const lastDot = clean.lastIndexOf(".");
+	if (lastDot === -1) {
+		return "jpg";
+	}
+
+	return clean.substring(lastDot + 1);
+}
+
+export async function save_to_folder(app: App, folder_path: string, image: DownloadedImage) {
+	const targetFolder = normalizePath(folder_path.trim());
+
+	if (targetFolder && !(await app.vault.adapter.exists(targetFolder))) {
+		await app.vault.createFolder(targetFolder);
+	}
+
+	image.file_name = await unique_file_name(app, targetFolder, image.file_name, image.extension);
+
+	const fullPath = normalizePath(`${targetFolder}/${image.file_name}.${image.extension}`);
+	await app.vault.createBinary(fullPath, image.content);
+}
+
+async function unique_file_name(app: App, folder: string, file_name: string, extension: string): Promise<string> {
+	let candidate = file_name;
+	let i = 1;
+
+	while (await app.vault.adapter.exists(normalizePath(`${folder}/${candidate}.${extension}`))) {
+		candidate = `${file_name}_${i}`;
+		i++;
+	}
+
+	return candidate;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -101,6 +101,11 @@ export function replace_date_in_(input: string) {
 	return output;
 }
 
+export function is_entry_in_template(entry_name: string, template_text: string): boolean{
+	const regex = new RegExp(`{{\\s*${entry_name}\\s*}}`, "i");
+	return regex.test(template_text);
+}
+
 function replacer(str: string, reg: RegExp, replace_value: string) {
 	return str.replace(reg, function () {
 		return replace_value;


### PR DESCRIPTION
Adds an option in the settings that takes a path to a folder where the images will be downloaded. If the path is empty, it will keep using the image link

<img width="1124" height="105" alt="image" src="https://github.com/user-attachments/assets/81c6c99c-6572-44bc-8445-6892b356c573" />